### PR TITLE
bug fix of minimum positive value

### DIFF
--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -13,9 +13,9 @@ def boxcox_transform(data, texp=4):
     # mode: box-cox; power-law
     if not isinstance(data, np.ndarray):
         data = np.array(data)
+    data = data.copy()
     data[data<0] = 0
     datat = (data ** (1 / texp) - 1) / (1 / texp)
-    # datat[data < -3] = -3
     return datat
 
 def boxcox_back_transform(data, texp=4):
@@ -23,6 +23,7 @@ def boxcox_back_transform(data, texp=4):
     # mode: box-cox; power-law
     if not isinstance(data, np.ndarray):
         data = np.array(data)
+    data = data.copy()
     data[data<-texp] = -texp
     datat = (data / texp + 1) ** texp
     return datat


### PR DESCRIPTION
The bug affects cases where the precipitation should happen but the probabilistic estimate is zero due to negative perturbation. The codes should assign a small value 0.1 to those case, but the previous code did this before the transformation. As the result, the value becomes 1.1038 after back transformation.