### PR TITLE
Addition of Empirical CDF transform

### DIFF
--- a/docs/How_to_create_config_files.md
+++ b/docs/How_to_create_config_files.md
@@ -234,7 +234,7 @@ dynamic_predictor_name = [['cube_root_prec_rate', 'tmp_2m'],
 
 ## predictor_name_static_stn
 This list contains names of static predictors of input stations that will be used to support gridding estimation. These variables must be contained in `input_stn_list` or `input_stn_all`.  
-Example: `predictor_name_static_stn = ['lat', 'lon', 'elev', 'slp_n', 'slp_e']` 
+Example: `predictor_name_static_stn = ['lat', 'lon', 'elev', 'slp_n', 'slp_e']`
 
 ## predictor_name_static_grid
 
@@ -312,7 +312,7 @@ Sklearn module is used to support most functions: https://scikit-learn.org/stabl
 (2) Sklearn-based methods support simple usage with `model.fit()` and `model.predict` or `model.predict_prob`, in the format of `LWR:linear_model.METHOD`. Examples of METHOD are `LinearRegression`, `LogisticRegression`, `Ridge`, `BayesianRidge`, `ARDRegression`, `Lasso`, `ElasticNet`, `Lars`, etc.  
 
 - Global regression using machine learnig methods:
-Machine learning methods are supported by sklearn. Parametrs of methods supported by sklearn can be defined at the bottom of this configuration file (optional). Examples: `ensemble.RandomForestRegressor`, `ensemble.RandomForestClassifier`, `neural_network.MLPRegressor`, `neural_network.MLPClassifier`, `ensemble.GradientBoostingClassifier`, and `ensemble.GradientBoostingRegressor`. 
+Machine learning methods are supported by sklearn. Parametrs of methods supported by sklearn can be defined at the bottom of this configuration file (optional). Examples: `ensemble.RandomForestRegressor`, `ensemble.RandomForestClassifier`, `neural_network.MLPRegressor`, `neural_network.MLPClassifier`, `ensemble.GradientBoostingClassifier`, and `ensemble.GradientBoostingRegressor`.
 
 The parameters of sklearn methods can be defined in the [sklearn] section.  
 
@@ -366,16 +366,31 @@ These parameters define the names of the latitude and longitude dimensions in th
 
 
 ## [transform]
-Transformation section. This will be read as a dictionary in Python. Current, only `boxcox` transformation is supported. 
+Transformation section. This will be read as a dictionary in Python. Currently,`boxcox` and `ecdf` transformation is supported. Please note that `ecdf` is still experimental, and requires a longer station data record to be provided to build the empirical cdf (ecdf).
+
 ### [transform.boxcox]
 #### exponent
 The exponential factor used in box-cox transformation. Example: `exponent = 4`.
 
+### [transform.ecdf]
+#### pooled
+Boolean to describe if a pooled (True) or station ecdf approach is taken. Example: `pooled=True`.
+#### min_z_value
+This is a value to be assigned to all nan values, following the ecdf transform. It represents a lower standard score (z), in the case of precipitation, it corresponds to a near zero amount. Example: `min_z_value=-4`.
+#### interp_method
+Selection of the method to translate cumulative probabilities back to measurements values in the ecdf back transform. Current options are linear interpolation with extrapolation, and a gamma distribution fit.
+Example: `interp_method=interp1d`, `interp_method=gamma`.
+
+#### min_est_value
+Very small values from back transformation below this threshold value are converted to nan, and then zero. Minimum estimated value is used a a cut off for mariginal values that are created in the regression process.
+Example: `min_est_value=0.01`.
+
+
 ## [sklearn]
 *Optional*
 scikit-learn section defining the parameters of sklearn methods used by `gridcore_continuous` and `gridcore_classification`. If no parameters are provided or if the section does not even exist, default parameters will be used.    
-Note: Use the pure name of sklearn method as the sub-dict name. For example, if `gridcore_continuous='ensemble.RandomForestRegressor'`, define the parameters of `ensemble.RandomForestRegressor` under the section `[sklearn.RandomForestRegressor]` (see the example). Don't inlcude `ensemble.` in the dict name. Similarly, if `gridcore_continuous='LWR:linear_model.Ridge'`, define the parameters of `Ridge` under the section `sklearn.Ridge`. 
- 
+Note: Use the pure name of sklearn method as the sub-dict name. For example, if `gridcore_continuous='ensemble.RandomForestRegressor'`, define the parameters of `ensemble.RandomForestRegressor` under the section `[sklearn.RandomForestRegressor]` (see the example). Don't inlcude `ensemble.` in the dict name. Similarly, if `gridcore_continuous='LWR:linear_model.Ridge'`, define the parameters of `Ridge` under the section `sklearn.Ridge`.
+
 Example:
 ### [sklearn.RandomForestRegressor]
 #### n_estimators   = 500
@@ -403,4 +418,4 @@ If set to `true`, all configurations will be printed at the beginning of model p
 **overwrite_grid_reg**: For gridded regression file  
 **overwrite_ens**: For ensemble output files  
 **overwrite_spcorr**: For spatial correlation structure files  
-By default, these flags are all `flase` to utilize existing outputs to speed up production. Users may change them to `true` to generate brand new files for all or part of GPEP outputs to overwrite existing files. A safer way is to just change `outpath_parent` to create files in a new folder.  
+By default, these flags are all `false` to utilize existing outputs to speed up production. Users may change them to `true` to generate brand new files for all or part of GPEP outputs to overwrite existing files. A safer way is to just change `outpath_parent` to create files in a new folder.  

--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -183,14 +183,15 @@ def inverse_normal_quantile_transform(data,time,monthly_cdfs, settings):
                     back_transformed_data.loc[z_scores.index, station] = np.zeros(len(z_scores))
 
     #Convert to array
-    back_transformed_data_array = back_transformed_data.astype(float).to_numpy()
-    back_transformed_data_array_transformed = back_transformed_data_array.T
+    back_transform_array = back_transformed_data.astype(float).to_numpy()
+    
 
     #Extra transform for grid regression
     if data.ndim == 3:
-       back_transformed_data_array_transformed = back_transformed_data_array_transformed.reshape(np.shape(data))
+       back_transform_array = back_transform_array.T
+       back_transform_array = back_transform_array.reshape(np.shape(data))
 
-    return back_transformed_data_array_transformed
+    return back_transform_array
 
 def data_transformation(data, method, settings, mode='transform',times=None,cdfs=None):
     if method == 'boxcox':

--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -4,7 +4,8 @@ import os, time, sys
 import pandas as pd
 import numpy as np
 import xarray as xr
-
+from scipy.stats import norm, gamma
+from scipy.interpolate import interp1d
 ########################################################################################################################
 # data transformation
 
@@ -28,7 +29,6 @@ def boxcox_back_transform(data, texp=4):
     datat = (data / texp + 1) ** texp
     return datat
 
-
 def boxcox_back_transform_biasadjustment(data, sigma_square, texp=4):
     # Box-Cox back transformation can lead to bias
     # This function is put here for future use
@@ -44,7 +44,154 @@ def boxcox_back_transform_biasadjustment(data, sigma_square, texp=4):
 
     return datat
 
-def data_transformation(data, method, settings, mode='transform'):
+def create_cdf_df(data):
+    """Helper function to calculate the CDF for a given month."""
+    valid_data = data[data > 0]
+    sorted_data = np.sort(valid_data)
+    cdf_values = np.arange(1, len(sorted_data) + 1) / len(sorted_data)
+    return pd.DataFrame({'Value': sorted_data, 'CDF': cdf_values})
+
+def calculate_monthly_cdfs(ds,var_name,settings):
+    """Create monthly empiricial CDFs."""
+
+    pooled = settings.get('pooled', True)
+
+    df = pd.DataFrame(data=ds[var_name].T.values, index=pd.to_datetime(ds['time']))
+
+    if pooled:
+        cdfs = {month: create_cdf_df(df[df.index.month == month].values.flatten())
+                for month in range(1, 13)}
+    else:
+        cdfs = {station: {month: create_cdf_df(df[station][df.index.month == month].dropna())
+                         for month in range(1, 13)}
+                for station in df.columns}
+    return cdfs
+
+def normal_quantile_transform(data,times, monthly_cdfs, settings):
+    """
+    Apply a normal quantile transform to the precipitation data using a pooled monthly empirical cdf.
+    """
+
+    # Read settings and if not available, assign default value
+    pooled = settings.get('pooled', True)
+    min_z_value = settings.get('min_z_value', -4)
+
+    df = pd.DataFrame(data=data.T, index=times)
+    transformed_data = pd.DataFrame(index=df.index, columns=(df.columns if pooled else None))
+
+    # Read all stations that only contain nan values
+    nan_columns = [col for col in df.columns if df[col].isna().all()]
+
+    for month in range(1, 13):
+        for station in (df.columns if not pooled else [None]):    
+
+            month_data = df[station][df.index.month == month] if not pooled else df[df.index.month == month]
+            month_data = month_data[month_data > 0]
+            
+            empirical_cdf = monthly_cdfs.get(month) if pooled else monthly_cdfs[station][month]
+            
+            if empirical_cdf is not None and not empirical_cdf.empty:
+
+                cdf_interp = interp1d(empirical_cdf['Value'], empirical_cdf['CDF'],bounds_error=True)
+                cum_probs = np.clip(cdf_interp(month_data),0,0.9999)
+                z_scores = norm.ppf(cum_probs)
+            
+                if pooled:
+                    transformed_data.loc[month_data.index, :] = z_scores
+                else:
+                    transformed_data.loc[month_data.index, station] = z_scores
+            else:
+                if pooled:
+                    transformed_data.loc[month_data.index, :] = np.nan
+                else:
+                    transformed_data.loc[month_data.index, station] = np.nan
+            
+
+        transformed_data_array = transformed_data.astype(float).to_numpy()
+
+        #Assign min value to all nan
+        transformed_data_filled = np.nan_to_num(transformed_data_array,nan=min_z_value)
+
+        #Remove stations that had nan from start
+        for col_index, col_name in enumerate(df.columns):
+            if col_name in nan_columns:
+                transformed_data_filled[:, col_index] = np.nan
+
+    return transformed_data_filled
+
+def inverse_normal_quantile_transform(data,time,monthly_cdfs, settings):
+    """
+    Reverse the normal quantile transform applied to the precipitation data using a monthly empirical cdf.
+    """
+    
+    #Read settings value, and if not assign default value
+    pooled = settings.get('pooled', True)
+    interp_method = settings.get('interp_method', 'interp1d')
+    min_est_value = settings.get('min_est_value', 0.01)
+
+    if data.ndim == 3: #Grid regression
+        flattened_data = data.reshape(-1, len(data[0,0,]))
+        transformed_data = pd.DataFrame(flattened_data.T, index=time)
+        back_transformed_data = pd.DataFrame(index=transformed_data.index, columns=transformed_data.columns)
+    elif data.ndim == 2: #Station regression
+        transformed_data = pd.DataFrame(data.T, index=time)
+        back_transformed_data = pd.DataFrame(index=transformed_data.index, columns=transformed_data.columns)
+
+    for month in range(1, 13):
+        for station in (transformed_data.columns if not pooled else [None]):
+            
+            # Get z scores for each month, and for unpooled approach for each station
+            z_scores = transformed_data[station][transformed_data.index.month == month] if not pooled else transformed_data[transformed_data.index.month == month]
+            # Get precomputed ecdf values
+            empirical_cdf = monthly_cdfs.get(month) if pooled else monthly_cdfs[station][month]
+
+            if empirical_cdf is not None and not empirical_cdf.empty:
+
+                if interp_method == 'interp1d':
+                    # Use linear interpolation for the inverse transformation
+                    value_interp = interp1d(empirical_cdf['CDF'], empirical_cdf['Value'], kind='linear', bounds_error=False, fill_value='extrapolate')
+                    # Calculate cumulative probabilities from z scores
+                    z_score_float = z_scores.values.astype(float)
+                    cum_probs = norm.cdf(z_score_float)
+                    # Use linear interpolation to sample from probabilities back to values
+                    original_values = value_interp(cum_probs)
+                
+                elif interp_method == 'gamma':
+                    # Fit a gamma distribution to the empirical CDF
+                    a, loc, scale = gamma.fit(empirical_cdf['Value'])
+                    # Define the inverse CDF (percent point function) of the fitted gamma distribution
+                    gamma_ppf = lambda cum_probs: gamma.ppf(cum_probs, a, loc, scale)
+                    # Calculate cumulative probabilities from z scores
+                    z_score_float = z_scores.values.astype(float)
+                    cum_probs = norm.cdf(z_score_float)
+                    # Use gamma distribution to sample from probabilities back to values
+                    original_values = gamma_ppf(cum_probs)
+                
+                #Filter small values created from filling of nan during first transform
+                original_values[original_values < min_est_value] = np.nan
+                #Convert all nan to zero
+                original_values = np.nan_to_num(original_values)
+
+                if pooled:
+                    back_transformed_data.loc[z_scores.index, :] = original_values
+                else:
+                    back_transformed_data.loc[z_scores.index, station] = original_values
+            else:
+                if pooled:
+                    back_transformed_data.loc[z_scores.index, :] = np.zeros(len(z_scores))
+                else:
+                    back_transformed_data.loc[z_scores.index, station] = np.zeros(len(z_scores))
+
+    #Convert to array
+    back_transformed_data_array = back_transformed_data.astype(float).to_numpy()
+
+    #Extra transform for grid regression
+    if data.ndim == 3:
+        back_transformed_data_array = back_transformed_data_array.reshape(np.shape(data))
+
+    return back_transformed_data_array
+
+def data_transformation(data, method, settings, mode='transform',times=None,cdfs=None):
     if method == 'boxcox':
         if mode == 'transform':
             data = boxcox_transform(data, settings['exponent'])
@@ -52,6 +199,17 @@ def data_transformation(data, method, settings, mode='transform'):
             data = boxcox_back_transform(data, settings['exponent'])
         else:
             print('Unknown transformation mode: entry=', mode); sys.exit()
+    elif method == 'ecdf':
+        if mode == 'transform':
+            data = normal_quantile_transform(data,times,cdfs,settings)
+            data = data.T
+        elif mode == 'back_transform':
+            data = inverse_normal_quantile_transform(data,times,cdfs,settings)
+            if data.ndim == 2:
+                data = data.T
+        else:
+            print('Unknown transformation mode: entry=', mode)
+            sys.exit()
     else:
         print('Unknown transformation method: entry=', method); sys.exit()
     return data
@@ -104,7 +262,7 @@ def merge_stndata_into_single_file(config):
         if isinstance(maxRange_vars, (int, float)):
             maxRange_vars = [maxRange_vars] * len(target_vars)
     else:
-        minRange_vars = [np.inf] * len(target_vars)
+        maxRange_vars = [np.inf] * len(target_vars)
 
     if 'transform_vars' in config:
         transform_vars = config['transform_vars']
@@ -234,8 +392,14 @@ def merge_stndata_into_single_file(config):
                 print(f'{tvar} exists in ds_stn. no need to perform transformation')
                 continue
             ds_stn[tvar] = ds_stn[vari].copy()
-            ds_stn[tvar].values = data_transformation(ds_stn[target_vars[i]].values, transform_vars[i],
-                                                      transform_settings[transform_vars[i]], 'transform')
+            if transform_vars[i] == 'ecdf':
+                cdfs = calculate_monthly_cdfs(ds_stn,target_vars[i],transform_settings[transform_vars[i]])
+                ds_stn[tvar].values = data_transformation(ds_stn[target_vars[i]].values, transform_vars[i],
+                                                transform_settings[transform_vars[i]], 'transform',
+                                                times=ds_stn['time'].values,cdfs=cdfs)
+            else:
+                ds_stn[tvar].values = data_transformation(ds_stn[target_vars[i]].values, transform_vars[i],
+                                                transform_settings[transform_vars[i]], 'transform')
         else:
             print(f'Do not perform transformation for {target_vars[i]}')
 

--- a/src/data_processing.py
+++ b/src/data_processing.py
@@ -184,12 +184,13 @@ def inverse_normal_quantile_transform(data,time,monthly_cdfs, settings):
 
     #Convert to array
     back_transformed_data_array = back_transformed_data.astype(float).to_numpy()
+    back_transformed_data_array_transformed = back_transformed_data_array.T
 
     #Extra transform for grid regression
     if data.ndim == 3:
-        back_transformed_data_array = back_transformed_data_array.reshape(np.shape(data))
+       back_transformed_data_array_transformed = back_transformed_data_array_transformed.reshape(np.shape(data))
 
-    return back_transformed_data_array
+    return back_transformed_data_array_transformed
 
 def data_transformation(data, method, settings, mode='transform',times=None,cdfs=None):
     if method == 'boxcox':

--- a/src/probabilistic_estimation.py
+++ b/src/probabilistic_estimation.py
@@ -8,7 +8,7 @@ from scipy import special
 from multiprocessing import Pool
 
 import random_field_FortranGMET as rf_FGMET
-from data_processing import data_transformation
+from data_processing import data_transformation, calculate_monthly_cdfs 
 
 # ====== subroutines/ functions ======
 
@@ -67,14 +67,19 @@ def perturb_estimates_general(data, uncert, rndnum, minrndnum=-3.99, maxrndnum=3
 
 
 def prob_estimate_for_one_var(var_name, reg_estimate, reg_error, nearby_stn_max, poe, random_field, minrndnum, maxrndnum,
-                              transform_method, transform_setting, ds_out):
+                              transform_method, transform_setting, ds_out,config):
     # generate probabilistic estimates
     if poe.shape == reg_estimate.shape:
 
         ens_estimate, index_positive, index_nonpositive = perturb_estimates_withoccurrence(reg_estimate, reg_error, poe, random_field, minrndnum, maxrndnum)
         # back transformation
         if len(transform_method) > 0:
-            ens_estimate = data_transformation(ens_estimate, transform_method, transform_setting, 'back_transform')
+            if transform_method == 'ecdf':
+                cdfs = calculate_monthly_cdfs(xr.open_dataset(config['file_allstn']),var_name)
+                ens_estimate = data_transformation(ens_estimate, transform_method, transform_setting, 'back_transform',
+                                                times=ds_out['time'].values,cdfs=cdfs)
+            else:
+                ens_estimate = data_transformation(ens_estimate, transform_method, transform_setting, 'back_transform')
 
             zerovalue = 0  # assume 0 is non-event value
             ens_estimate[index_nonpositive] = zerovalue
@@ -90,7 +95,12 @@ def prob_estimate_for_one_var(var_name, reg_estimate, reg_error, nearby_stn_max,
     if np.array(nearby_stn_max).shape == reg_estimate.shape:
         if len(transform_method) > 0:
             precip_err_cap = 0.2 # hard coded ...
-            nearby_stn_max = data_transformation(nearby_stn_max+reg_error*precip_err_cap, transform_method, transform_setting, 'back_transform')
+            if transform_method == 'ecdf':
+                cdfs = calculate_monthly_cdfs(xr.open_dataset(config['file_allstn']),var_name)
+                nearby_stn_max = data_transformation(nearby_stn_max+reg_error*precip_err_cap, transform_method, transform_setting, 'back_transform',
+                                                times=ds_out['time'].values,cdfs=cdfs)
+            else:
+                nearby_stn_max = data_transformation(nearby_stn_max+reg_error*precip_err_cap, transform_method, transform_setting, 'back_transform')
         else:
             nearby_stn_max = nearby_stn_max + reg_error * 2
         mask = ens_estimate > nearby_stn_max
@@ -492,7 +502,7 @@ def generate_prob_estimates_serial(config, member_range=[]):
             ds_out = prob_estimate_for_one_var(var_name, allvar_reg_estimate[var_name], allvar_reg_error[var_name],
                                                nearby_stn_max[var_name], allvar_poe[var_name], random_field,
                                                minrndnum, maxrndnum, transform_vars[var_name],
-                                               transform_settings[transform_vars[var_name]], ds_out)
+                                               transform_settings[transform_vars[var_name]], ds_out, config)
 
             if output_randomfield == True:
                 ds_out[var_name + '_rnd'] = xr.DataArray(random_field, dims=('y', 'x', 'time'))
@@ -518,7 +528,7 @@ def generate_prob_estimates_serial(config, member_range=[]):
                     ds_out = prob_estimate_for_one_var(var_name_dep, allvar_reg_estimate[var_name_dep], allvar_reg_error[var_name_dep],
                                                        nearby_stn_max[var_name], allvar_poe[var_name_dep], random_field_dep,
                                                        minrndnum, maxrndnum, transform_vars[var_name_dep],
-                                                       transform_settings[transform_vars[var_name_dep]], ds_out)
+                                                       transform_settings[transform_vars[var_name_dep]], ds_out, config)
 
                     if output_randomfield == True:
                         ds_out[var_name + '_rnd'] = xr.DataArray(random_field_dep, dims=('y', 'x', 'time'))

--- a/src/probabilistic_estimation.py
+++ b/src/probabilistic_estimation.py
@@ -75,7 +75,7 @@ def prob_estimate_for_one_var(var_name, reg_estimate, reg_error, nearby_stn_max,
         # back transformation
         if len(transform_method) > 0:
             if transform_method == 'ecdf':
-                cdfs = calculate_monthly_cdfs(xr.open_dataset(config['file_allstn']),var_name)
+                cdfs = calculate_monthly_cdfs(xr.open_dataset(config['file_allstn']),var_name, transform_setting)
                 ens_estimate = data_transformation(ens_estimate, transform_method, transform_setting, 'back_transform',
                                                 times=ds_out['time'].values,cdfs=cdfs)
             else:
@@ -96,7 +96,7 @@ def prob_estimate_for_one_var(var_name, reg_estimate, reg_error, nearby_stn_max,
         if len(transform_method) > 0:
             precip_err_cap = 0.2 # hard coded ...
             if transform_method == 'ecdf':
-                cdfs = calculate_monthly_cdfs(xr.open_dataset(config['file_allstn']),var_name)
+                cdfs = calculate_monthly_cdfs(xr.open_dataset(config['file_allstn']),var_name, transform_setting)
                 nearby_stn_max = data_transformation(nearby_stn_max+reg_error*precip_err_cap, transform_method, transform_setting, 'back_transform',
                                                 times=ds_out['time'].values,cdfs=cdfs)
             else:


### PR DESCRIPTION
Addition of Empirical CDF transforms from Clark and Slater (2006). 

This includes transform and back transform functions for ECDFs.

Pooled monthly ecdf transform (all stations together) is available through grid regression, while the unpooled (monthly ecdfs per station) works only until station regression cross validation. If this is carried for further use, methods to extend the unpooled ecdfs to grid cells will be needed.

Options for back transformation are linear interpolation and gamma fit. These currently show comparable results

Further testing through to ensemble generation, and of options is needed. However wanted to have this current working version added to the develop branch.